### PR TITLE
Use TeX macro for pdfauthor dash

### DIFF
--- a/ou-tma.sty
+++ b/ou-tma.sty
@@ -186,7 +186,7 @@ linkcolor=blue,%
 urlcolor=blue,%
 pdfstartview=FitH,%
 pdftitle={TMA~\tma}, %
-pdfauthor={\name~—~\pin}, %
+  pdfauthor={\name~\textemdash~\pin}, %
 pdfkeywords={OUCU:~\pin, TMA~\tma}, %
 pdfsubject=\course%
 }%


### PR DESCRIPTION
## Summary
- replace the literal Unicode em dash in the pdfauthor metadata with a TeX macro so pdfLaTeX can process the pdfbookmark option

## Testing
- ⚠️ `pdflatex -interaction=nonstopmode -halt-on-error examples/SampleTMA.tex` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913aad5eb008327bfa115db51949520)

## Summary by Sourcery

Enhancements:
- Replace literal Unicode em dash in pdfauthor with \textemdash macro in ou-tma.sty