### PR TITLE
Adjust roman override numbering overrides

### DIFF
--- a/tests/roman_test.tex
+++ b/tests/roman_test.tex
@@ -33,8 +33,11 @@ Expected tags at end of each line.
 \qsubpart
 \lipsum[2][6-8] \emph{(ii)(b)}
 
-\qpart
-\lipsum[3][1] \emph{(iii)}
+\qpart[4]% expected tag (iv)
+\lipsum[3][1] \emph{(iv)}
+
+\qsubpart[6]% expected tag (iv)(f)
+\lipsum[3][2] \emph{(iv)(f)}
 \end{question}
 
 \end{document}


### PR DESCRIPTION
## Summary
- update the roman numbering test to use numeric overrides for the forced tags
- keep inline expectations showing the resulting (iv) and (iv)(f) markers

## Testing
- not run (pdflatex unavailable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913aab8555c83279191db77a6c2f6f0)

## Summary by Sourcery

Tests:
- Update roman_test.tex to use numeric overrides for qpart and qsubpart numbering and retain inline expectations for (iv) and (iv)(f) markers